### PR TITLE
增加runnerup.super-encourager下载统计

### DIFF
--- a/src/assets/extensions.json
+++ b/src/assets/extensions.json
@@ -117,5 +117,6 @@
     "manasxx.PHPDocument",
     "manasxx.background-cover",
     "manasxx.nest",
-    "manasxx.max"
+    "manasxx.max",
+    "runnerup.super-encourager"
 ]


### PR DESCRIPTION
runnerup.super-encourager （超级鼓励师） 是一款旨在为开发者提供美图，名言，方便开发的小工具，常见API等周边服务的vscode扩展。
ps：请教一下如何统计的下载量的变化？  是自己的数据库和服务定时轮询记录 还是有api直接可以拿到？  我现在是用node请求https://marketplace.visualstudio.com/items?itemName=RUNNERUP.super-encourager&ssr=false#overview  正则解析html文本拿到的  太low了